### PR TITLE
Cachix documentation and agent config reference

### DIFF
--- a/assets/theme.css
+++ b/assets/theme.css
@@ -4,8 +4,9 @@ html, body {
   font-family:"Fira Sans",Helvetica Neue,Arial,Helvetica,sans-serif !important;
 }
 
-#toc {
-  display: none;
+#toc ul {
+  /* work around otherwise broken css */
+  margin-left: 1.25em !important;
 }
 
 /* Responsiveness fixes */
@@ -24,4 +25,5 @@ table {
 
 pre {
   font-size: large;
+}
 }

--- a/docs/agent-config.adoc
+++ b/docs/agent-config.adoc
@@ -1,10 +1,11 @@
 = Agent configuration file
 
-The agent can be run with a configuration by invoking `hercules-ci-agent --config agent.toml`
-formatted using https://github.com/toml-lang/toml#toml[TOML] markup.
+When deploying with NixOS, NixOps or nix-darwin you should use the module
+documentation instead, or skip ahead to read about less frequently used options
+to use with `extraOptions`.
 
-When deploying with NixOS, NixOps or nix-darwin you don't need to specify the config file,
-but rather configure the service via Nix.
+The configuration format for the agent is https://github.com/toml-lang/toml#toml[TOML] markup.
+Its location must always be specified by invoking `hercules-ci-agent --config agent.toml`.
 
 A basic `agent.toml` looks as follows:
 
@@ -15,38 +16,32 @@ baseDirectory = "/var/lib/hercules-ci-agent"
 concurrentTasks = 4
 ----
 
+== apiBaseUrl
+
+Optional. Defaults to `https://hercules-ci.com`.
+
+HTTP API agent will connect to.
+
 == baseDirectory
 
 Required.
 
 Directory with all the agent state: secrets, work, etc.
 
-== apiBaseUrl
-
-Optional. Defaults to https://hercules-ci.com.
-
-HTTP API agent will connect to.
-
-== clusterJoinTokenPath
-
-Optional. Defaults to ${baseDirectory}/cluster-join-token.key.
-
-Path to a secret token retrieved when creating a new agent via
-https://hercules-ci.com for HTTP API authentication.
-
-== concurrentTasks
-
-Optional. Defaults to 4.
-
-Number of workers to use for building/evaluating Nix derivations.
-
 == binaryCachesPath
 
-Optional. Defaults to ${baseDirectory}/binary-caches.json
+Optional. Defaults to `_staticSecretsDirectory_/binary-caches.json` if that file exists.
 
 Path to a JSON file containing binary cache secret keys.
 
 Currently only supports http://cachix.org/[Cachix] binary caches.
+
+Note that binary cache configuration affects the whole system's Nix configuration.
+
+Make sure that your system accepts the binary cache. We currently recommend
+to look at the
+https://github.com/hercules-ci/hercules-ci-agent/search?l=Nix&q=cache[sources]
+for details.
 
 Example:
 
@@ -61,3 +56,35 @@ binary-caches.json
     }
 }
 ----
+
+== clusterJoinTokenPath
+
+Optional. Defaults to `_staticSecretsDirectory_/cluster-join-token.key`.
+
+Path to a secret token retrieved when creating a new agent via
+https://hercules-ci.com/dashboard.
+
+This token is used for authenticating to `_apiBaseUrl_`.
+
+== concurrentTasks
+
+Optional. Defaults to 4.
+
+Combined number of workers to use for building and evaluating Nix derivations.
+
+The optimal value depends on the resource consumption characteristics of your workload,
+including memory usage and in-task parallelism. This is typically determined empirically.
+
+== staticSecretsDirectory
+
+Optional. Defaults to `_baseDirectory_/secrets`.
+
+This is the default directory to look for statically configured secrets like
+clusterJoinTokenPath.
+
+== workDirectory
+
+Optional. Defaults to `_baseDirectory_/work`.
+
+The directory in which temporary subdirectories are created for task state.
+This includes sources for Nix evaluation.

--- a/docs/agent-config.adoc
+++ b/docs/agent-config.adoc
@@ -1,0 +1,63 @@
+= Agent configuration file
+
+The agent can be run with a configuration by invoking `hercules-ci-agent --config agent.toml`
+formatted using https://github.com/toml-lang/toml#toml[TOML] markup.
+
+When deploying with NixOS, NixOps or nix-darwin you don't need to specify the config file,
+but rather configure the service via Nix.
+
+A basic `agent.toml` looks as follows:
+
+agent.toml
+[source,toml]
+----
+baseDirectory = "/var/lib/hercules-ci-agent"
+concurrentTasks = 4
+----
+
+== baseDirectory
+
+Required.
+
+Directory with all the agent state: secrets, work, etc.
+
+== apiBaseUrl
+
+Optional. Defaults to https://hercules-ci.com.
+
+HTTP API agent will connect to.
+
+== clusterJoinTokenPath
+
+Optional. Defaults to ${baseDirectory}/cluster-join-token.key.
+
+Path to a secret token retrieved when creating a new agent via
+https://hercules-ci.com for HTTP API authentication.
+
+== concurrentTasks
+
+Optional. Defaults to 4.
+
+Number of workers to use for building/evaluating Nix derivations.
+
+== binaryCachesPath
+
+Optional. Defaults to ${baseDirectory}/binary-caches.json
+
+Path to a JSON file containing binary cache secret keys.
+
+Currently only supports http://cachix.org/[Cachix] binary caches.
+
+Example:
+
+binary-caches.json
+[source,json]
+----
+{ "my-private":
+    { "kind": "CachixCache",
+      "authToken": "eyJhaf23GH53a.bc23BUSI.9q3048hWHh"
+    , "publicKeys": ["my-private.cachix.org-1:EjBSHzF6VmDnzqlldGXbi0RM3HdjfTU3yDRi9Pd0jTY="]
+    , "signingKeys": ["XXX"]
+    }
+}
+----

--- a/docs/agent-config.adoc
+++ b/docs/agent-config.adoc
@@ -12,8 +12,7 @@ A basic `agent.toml` looks as follows:
 agent.toml
 [source,toml]
 ----
-baseDirectory = "/var/lib/hercules-ci-agent"
-concurrentTasks = 4
+include::agent-small-example.toml[]
 ----
 
 == apiBaseUrl

--- a/docs/agent-small-example.toml
+++ b/docs/agent-small-example.toml
@@ -1,0 +1,2 @@
+baseDirectory = "/var/lib/hercules-ci-agent"
+concurrentTasks = 4

--- a/docs/autogenerate/Cachix.adoc
+++ b/docs/autogenerate/Cachix.adoc
@@ -1,0 +1,38 @@
+If you're using more than one agent or would like to share
+resulting binaries outside the build farm you'll need a binary cache.
+
+On https://cachix.org[Cachix] you can create a binary cache and
+instruct the agent how to use it:
+
+binary-caches.json
+[source,json]
+----
+{ "my-private":
+    { "kind": "CachixCache",
+      "authToken": "eyJhaf23GH53a.bc23BUSI.9q3048hWHh"
+    , "publicKeys": ["my-private.cachix.org-1:EjBSHzF6VmDnzqlldGXbi0RM3HdjfTU3yDRi9Pd0jTY="]
+    , "signingKeys": ["XXX"]
+    }
+}
+----
+
+and specify `services.hercules-ci-agent.binaryCachesFile = ./binary-caches.json`
+in Nix configuration.
+
+On Darwin, you'll additionally need to manually install the file:
+
+[source,bash]
+----
+sudo install \
+    -o hercules-ci-agent  \
+    -m 0600 \
+    binary-caches.json \
+    /var/lib/hercules-ci-agent/secrets/binary-caches.json
+rm binary-caches.json
+----
+
+If the cache is public you should omit the `authToken` field.
+
+NOTE: We're working on https://cachix.org[Cachix] to be able to restrict `authToken`
+to only reading one private cache. https://github.com/cachix/feedback/issues/7[Subscribe to the issue to get notified]
+when the token should be replaced.

--- a/docs/autogenerate/Darwin.adoc
+++ b/docs/autogenerate/Darwin.adoc
@@ -9,9 +9,10 @@ nix-build https://github.com/hercules-ci/nix-darwin/archive/hercules-ci-agent.ta
 ./result/bin/darwin-installer
 ----
 
-When asked for editing the configuration.nix add:
+When asked for editing the `darwin-configuration.nix` add:
 
 [source,nix]
 ----
+services.nix-daemon.enable = true;
 services.hercules-ci-agent.enable = true;
 ----

--- a/docs/autogenerate/DarwinPostToken.adoc
+++ b/docs/autogenerate/DarwinPostToken.adoc
@@ -1,13 +1,13 @@
-Save the token to a new file `agent-join-token.key` on the machine and run:
+Save the token to a new file `cluster-join-token.key` on the machine and run:
 
 [source,bash]
 ----
 sudo install \
     -o hercules-ci-agent  \
     -m 0600 \
-    agent-join-token.key \
-    /var/lib/hercules-ci-agent/secrets/agent-join-token.key
-rm agent-join-token.key
+    cluster-join-token.key \
+    /var/lib/hercules-ci-agent/secrets/cluster-join-token.key
+rm cluster-join-token.key
 ----
 
 Tail /var/log/hercules-ci-agent.log to see what is going on with your agent.

--- a/docs/autogenerate/DarwinPostToken.adoc
+++ b/docs/autogenerate/DarwinPostToken.adoc
@@ -6,9 +6,8 @@ sudo install \
     -o hercules-ci-agent  \
     -m 0600 \
     agent-join-token.key \
-    /var/lib/hercules-ci-agent/agent-join-token.key
+    /var/lib/hercules-ci-agent/secrets/agent-join-token.key
 rm agent-join-token.key
 ----
 
 Tail /var/log/hercules-ci-agent.log to see what is going on with your agent.
-

--- a/docs/autogenerate/network.example.nix
+++ b/docs/autogenerate/network.example.nix
@@ -13,7 +13,7 @@ in
 
     services.hercules-ci-agent.enable = true;
     services.hercules-ci-agent.concurrentTasks = 4; # Number of jobs to run
-    services.hercules-ci-agent.binaryCachesFile = ./binary-caches.json.key;
+    services.hercules-ci-agent.binaryCachesFile = ./binary-caches.json;
     deployment.keys."cluster-join-token.key".keyFile = ./cluster-join-token.key;
   };
 }

--- a/docs/autogenerate/network.example.nix
+++ b/docs/autogenerate/network.example.nix
@@ -8,10 +8,12 @@ in
 
   agent = {
     imports = [
-      (hercules-ci-agent + "/nixops-profile.nix")
+      (hercules-ci-agent + "/module.nix")
     ];
 
-    deployment.keys."agent-token.key".keyFile = ./agent-token.key;
+    services.hercules-ci-agent.enable = true;
     services.hercules-ci-agent.concurrentTasks = 4; # Number of jobs to run
+    services.hercules-ci-agent.binaryCachesFile = ./binary-caches.json.key;
+    deployment.keys."cluster-join-token.key".keyFile = ./cluster-join-token.key;
   };
 }

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -1,3 +1,5 @@
+:sectlinks:
+:sectanchors:
 :toc: macro
 
 Hercules CI is a continuous integration service for Nix. In order to provide this service, it connects the following components:
@@ -119,6 +121,10 @@ This method of running the agent is not officially supported yet: its interface 
 
 To inspect the agent's local log, run `nixops ssh agent journalctl -u hercules-ci-agent -n 100` to see the last 100 lines.
 
+
+include::agent-config.adoc[]
+
+
 = FAQ / How To
 
 == My commit status is stuck in Pending - Waiting for agent
@@ -158,7 +164,6 @@ $ nix-build
 $ nix-shell --run 'nixops --version'
 NixOps 1.6.1
 ----
-
 == My attribute doesn't show up in the evaluation
 
 Is it in a nested attribute set? Make sure you call `pkgs.recurseIntoAttrs` on all levels of nested attrsets.

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -11,9 +11,6 @@ Hercules CI is a continuous integration service for Nix. In order to provide thi
 
 This document describes the steps to set up the integration. The process should be self-explanatory, guided by the https://hercules-ci.com[hercules-ci.com] web application. If you find yourself stuck, or if you want to know the process in advance, this document is intended to provide reference.
 
-EARLY ACCESS PHASE
-------------------
-
 [WARNING]
 ====
 This is preview software. We're https://github.com/hercules-ci/support[gathering feedback] to improve the service. It is not meant to be relied upon just yet.
@@ -25,96 +22,12 @@ Have a look at our https://github.com/hercules-ci/support/issues?q=is%3Aissue+is
 
 toc::[]
 
-= Step 1. GitHub Setup
 
-== Sign in
+= Setup Guide
 
- 1. Click the GitHub "Sign in" button on the top right of https://hercules-ci.com/dashboard[hercules-ci.com] and follow the steps.
+include::setup.adoc[leveloffset=+1]
 
- 2. Hercules-ci.com will now show the application instead of the regular front page.
-
-== Install the GitHub app
-
-Having signed in, you are ready to add Hercules CI to your GitHub user account or to a GitHub organization account.
-
- 1. Click the "Connect GitHub repositories" button near the top of the https://hercules-ci.com/dashboard[dashboard].
-
- 2. GitHub will give you a choice to install the application on all repositories,
-    which includes repositories to be created in the future, or to select specific
-    repositories. We recommend that you make a selection of repositories, assuming
-    not all your repositories have suitable Nix expressions. Follow the steps.
-
- 3. Write a `default.nix` in the root of your repository.
-+
-If `default.nix` is a function, it must define default arguments in order to be auto-callable. `NIX_PATH` will be empty.
-+
-Hercules CI behaves similarly to `nix-build`. `default.nix` can provide multiple derivations by returning an attribute set. Nested attribute sets can be traversed by calling Nixpkgs' `pkgs.recurseIntoAttrs`.
-
- 4. Test it locally by running the command
-+
-[source,bash]
-----
-myrepo/$ NIX_PATH= nix-build --no-out-link
-----
- 5. Commit and push, so Hercules CI will pick it up.
-
-== Collaborators
-
-Hercules CI will automatically pick up permissions from GitHub. Collaborators will find the repositories they have access to when they sign in.
-
-
-= Step 2. Agent Setup
-
-The agent adds itself to a cluster by means of a _cluster join token_. The same token may be used to add multiple agents.
-
-
-[WARNING]
-====
-When updating the agent token on a previously deployed agent, you will need to remove the `session.key` file and restart the agent in order to start using the new cluster join token.
-This file is stored in `/var/lib/hercules-ci-agent/session.key` by default. This will be resolved in https://github.com/hercules-ci/hercules-ci-agent/issues/8[issue #8]
-====
-
-== Deploy with NixOps
-
-1.
-include::autogenerate/Bootstrap.adoc[]
-
-2.
-include::autogenerate/Target.adoc[]
-
-3.
-
---
-a. In the https://hercules-ci.com/dashboard[dashboard], find the account for which you would like to deploy the agent,
-b. Click the "Agents" button and the button in "Generate token" tab. This produces a private token that should be protected like a password.
-c. Copy the token into a plain text file `cluster-join-token.key` in the same directory. Protect this file like a password.
---
-
-4.
-include::autogenerate/Deploy.adoc[]
-
-////
-
-TODO
-
-== Run locally
-
-
-The agent can be run on any machine by installing the agent and invoking the `hercules-agent` command. We recommend running the agent on machines that remain connected to the internet.
-
-This method of running the agent is not officially supported yet: its interface may change in incompatible ways.
-
-// TODO is running on your laptop sufficient for some situations?
-
-////
-
-== Troubleshooting
-
-To inspect the agent's local log, run `nixops ssh agent journalctl -u hercules-ci-agent -n 100` to see the last 100 lines.
-
-
-include::agent-config.adoc[]
-
+'''
 
 = FAQ / How To
 
@@ -177,6 +90,12 @@ Derivation logs are currently only available after the derivation has succeeded 
 
 You may run `nix-store --realise /nix/store/<...>.drv` on an agent for troubleshooting purposes.
 
-= Evaluation
+'''
 
-include::autogenerate/Evaluation.adoc[]
+= Reference
+
+== Evaluation
+
+include::autogenerate/Evaluation.adoc[leveloffset=+1]
+
+include::agent-config.adoc[leveloffset=+1]

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -65,22 +65,13 @@ Hercules CI will automatically pick up permissions from GitHub. Collaborators wi
 
 = Step 2. Agent Setup
 
-The agent adds itself to a cluster of agents by means of the agent join token.
+The agent adds itself to a cluster by means of a _cluster join token_. The same token may be used to add multiple agents.
 
-
-////
-// TODO multi-agent
-[NOTE]
-====
-The agent token will be used by the agent to request a token that identifies the agent itself. A single agent token can therefore be used to deploy a cluster of agents.
-====
-//
-////
 
 [WARNING]
 ====
-When updating the agent token on a previously deployed agent, you will need to remove the `identity.token` file and restart the agent in order to start using the new agent token.
-This file is stored in `~/.local/share/hercules-agent` by default. This will be resolved in https://github.com/hercules-ci/hercules-ci-agent/issues/8[issue #8]
+When updating the agent token on a previously deployed agent, you will need to remove the `session.key` file and restart the agent in order to start using the new cluster join token.
+This file is stored in `/var/lib/hercules-ci-agent/session.key` by default. This will be resolved in https://github.com/hercules-ci/hercules-ci-agent/issues/8[issue #8]
 ====
 
 == Deploy with NixOps

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -96,7 +96,7 @@ include::autogenerate/Target.adoc[]
 --
 a. In the https://hercules-ci.com/dashboard[dashboard], find the account for which you would like to deploy the agent,
 b. Click the "Agents" button and the button in "Generate token" tab. This produces a private token that should be protected like a password.
-c. Copy the token into a plain text file `agent-token.key` in the same directory. Protect this file like a password.
+c. Copy the token into a plain text file `cluster-join-token.key` in the same directory. Protect this file like a password.
 --
 
 4.

--- a/docs/setup.adoc
+++ b/docs/setup.adoc
@@ -40,12 +40,18 @@ Hercules CI will automatically pick up permissions from GitHub. Collaborators wi
 
 The agent adds itself to a cluster by means of a _cluster join token_. The same token may be used to add multiple agents.
 
-
 [WARNING]
 ====
 When updating the agent token on a previously deployed agent, you will need to remove the `session.key` file and restart the agent in order to start using the new cluster join token.
 This file is stored in `/var/lib/hercules-ci-agent/session.key` by default. This will be resolved in https://github.com/hercules-ci/hercules-ci-agent/issues/8[issue #8]
 ====
+
+Choose one of the deployment options:
+
+- link:#deploy-with-nixops[NixOps], for existing or provisioning NixOS machines
+// TODO: nix-darwin section and link
+- Nix-darwin, the recommended configuration management tool for Mac OS X
+- link:#deploy-manually-with-a-configuration-file[Manually], when the other deployment methods are not suitable
 
 == Deploy with NixOps
 
@@ -56,31 +62,52 @@ include::autogenerate/Bootstrap.adoc[]
 include::autogenerate/Target.adoc[]
 
 3.
+Get a cluster join token.
 
 --
-a. In the https://hercules-ci.com/dashboard[dashboard], find the account for which you would like to deploy the agent,
-b. Click the "Agents" button and the button in "Generate token" tab. This produces a private token that should be protected like a password.
-c. Copy the token into a plain text file `cluster-join-token.key` in the same directory. Protect this file like a password.
+- In the https://hercules-ci.com/dashboard[dashboard], find the account for which you would like to deploy the agent,
+- Click the "Agents" button and the button in "Generate token" tab. This produces a private token that should be protected like a password.
+- Copy the token into a plain text file `cluster-join-token.key` in the same directory. Protect this file like a password.
 --
 
 4.
 include::autogenerate/Deploy.adoc[]
 
-////
-
-TODO
-
-== Run locally
-
-
-The agent can be run on any machine by installing the agent and invoking the `hercules-agent` command. We recommend running the agent on machines that remain connected to the internet.
-
-This method of running the agent is not officially supported yet: its interface may change in incompatible ways.
-
-// TODO is running on your laptop sufficient for some situations?
-
-////
-
-== Troubleshooting
+=== Troubleshooting
 
 To inspect the agent's local log, run `nixops ssh agent journalctl -u hercules-ci-agent -n 100` to see the last 100 lines.
+
+== Deploy manually with a configuration file
+
+If the other deployment methods do not suit your needs, you choose to run it
+manually.
+
+1.
+Write an `agent.toml` file. Most of the entries are optional. A small example:
+
+[source,toml]
+----
+include::agent-small-example.toml[]
+----
+
+This guide assumes the that link:#basedirectory[`baseDirectory`] is set to `/var/lib/hercules-ci-agent`.
+
+2.
+Get a cluster join token.
+
+--
+- In the https://hercules-ci.com/dashboard[dashboard], find the account for which you would like to deploy the agent,
+- Click the "Agents" button and the button in "Generate token" tab. This produces a private token that should be protected like a password.
+- Copy the token into a plain text file `/var/lib/hercules-ci-agent/secrets/cluster-join-token.key`.
+--
+
+3.
+Write a link:#binarycachespath[binary caches file] to `/var/lib/hercules-ci-agent/secrets/binary-caches.json`.
+
+4.
+Configure the system to use the caches and accept their public keys.
+When using a private cache, you will also need to install an appropriate netrc
+file in `/etc/nix/daemon-netrc`.
+
+5.
+Start the agent with the command `hercules-agent --config agent.toml`.

--- a/docs/setup.adoc
+++ b/docs/setup.adoc
@@ -1,0 +1,86 @@
+= Step 1. GitHub Setup
+
+== Sign in
+
+ 1. Click the GitHub "Sign in" button on the top right of https://hercules-ci.com/dashboard[hercules-ci.com] and follow the steps.
+
+ 2. Hercules-ci.com will now show the application instead of the regular front page.
+
+== Install the GitHub app
+
+Having signed in, you are ready to add Hercules CI to your GitHub user account or to a GitHub organization account.
+
+ 1. Click the "Connect GitHub repositories" button near the top of the https://hercules-ci.com/dashboard[dashboard].
+
+ 2. GitHub will give you a choice to install the application on all repositories,
+    which includes repositories to be created in the future, or to select specific
+    repositories. We recommend that you make a selection of repositories, assuming
+    not all your repositories have suitable Nix expressions. Follow the steps.
+
+ 3. Write a `default.nix` in the root of your repository.
++
+If `default.nix` is a function, it must define default arguments in order to be auto-callable. `NIX_PATH` will be empty.
++
+Hercules CI behaves similarly to `nix-build`. `default.nix` can provide multiple derivations by returning an attribute set. Nested attribute sets can be traversed by calling Nixpkgs' `pkgs.recurseIntoAttrs`.
+
+ 4. Test it locally by running the command
++
+[source,bash]
+----
+myrepo/$ NIX_PATH= nix-build --no-out-link
+----
+ 5. Commit and push, so Hercules CI will pick it up.
+
+== Collaborators
+
+Hercules CI will automatically pick up permissions from GitHub. Collaborators will find the repositories they have access to when they sign in.
+
+
+= Step 2. Agent Setup
+
+The agent adds itself to a cluster by means of a _cluster join token_. The same token may be used to add multiple agents.
+
+
+[WARNING]
+====
+When updating the agent token on a previously deployed agent, you will need to remove the `session.key` file and restart the agent in order to start using the new cluster join token.
+This file is stored in `/var/lib/hercules-ci-agent/session.key` by default. This will be resolved in https://github.com/hercules-ci/hercules-ci-agent/issues/8[issue #8]
+====
+
+== Deploy with NixOps
+
+1.
+include::autogenerate/Bootstrap.adoc[]
+
+2.
+include::autogenerate/Target.adoc[]
+
+3.
+
+--
+a. In the https://hercules-ci.com/dashboard[dashboard], find the account for which you would like to deploy the agent,
+b. Click the "Agents" button and the button in "Generate token" tab. This produces a private token that should be protected like a password.
+c. Copy the token into a plain text file `cluster-join-token.key` in the same directory. Protect this file like a password.
+--
+
+4.
+include::autogenerate/Deploy.adoc[]
+
+////
+
+TODO
+
+== Run locally
+
+
+The agent can be run on any machine by installing the agent and invoking the `hercules-agent` command. We recommend running the agent on machines that remain connected to the internet.
+
+This method of running the agent is not officially supported yet: its interface may change in incompatible ways.
+
+// TODO is running on your laptop sufficient for some situations?
+
+////
+
+== Troubleshooting
+
+To inspect the agent's local log, run `nixops ssh agent journalctl -u hercules-ci-agent -n 100` to see the last 100 lines.

--- a/docs/setup.adoc
+++ b/docs/setup.adoc
@@ -43,7 +43,7 @@ The agent adds itself to a cluster by means of a _cluster join token_. The same 
 [WARNING]
 ====
 When updating the agent token on a previously deployed agent, you will need to remove the `session.key` file and restart the agent in order to start using the new cluster join token.
-This file is stored in `/var/lib/hercules-ci-agent/session.key` by default. This will be resolved in https://github.com/hercules-ci/hercules-ci-agent/issues/8[issue #8]
+This file is stored in `/var/lib/hercules-ci-agent/secretState/session.key` by default. This will be resolved in https://github.com/hercules-ci/hercules-ci-agent/issues/8[issue #8]
 ====
 
 Choose one of the deployment options:
@@ -70,6 +70,9 @@ Get a cluster join token.
 - Copy the token into a plain text file `cluster-join-token.key` in the same directory. Protect this file like a password.
 --
 
+3.
+Write a link:#binarycachespath[binary caches file], `binary-caches.json` in the same directory as `hercules-ci-agents.nix`.
+
 4.
 include::autogenerate/Deploy.adoc[]
 
@@ -79,10 +82,13 @@ To inspect the agent's local log, run `nixops ssh agent journalctl -u hercules-c
 
 == Deploy manually with a configuration file
 
-If the other deployment methods do not suit your needs, you choose to run it
-manually.
+If the other deployment methods do not suit your needs, you may choose to run or deploy the agent manually.
 
 1.
+Send us an e-mail at support@hercules-ci.com. We can give advice and
+we are interested in expanding our officially supported deployment methods.
+
+2.
 Write an `agent.toml` file. Most of the entries are optional. A small example:
 
 [source,toml]
@@ -90,9 +96,9 @@ Write an `agent.toml` file. Most of the entries are optional. A small example:
 include::agent-small-example.toml[]
 ----
 
-This guide assumes the that link:#basedirectory[`baseDirectory`] is set to `/var/lib/hercules-ci-agent`.
+This guide assumes that the link:#basedirectory[`baseDirectory`] is set to `/var/lib/hercules-ci-agent`.
 
-2.
+3.
 Get a cluster join token.
 
 --
@@ -101,13 +107,13 @@ Get a cluster join token.
 - Copy the token into a plain text file `/var/lib/hercules-ci-agent/secrets/cluster-join-token.key`.
 --
 
-3.
-Write a link:#binarycachespath[binary caches file] to `/var/lib/hercules-ci-agent/secrets/binary-caches.json`.
-
 4.
+Write a link:#binarycachespath[binary caches file] and install it in `/var/lib/hercules-ci-agent/secrets/binary-caches.json`.
+
+5.
 Configure the system to use the caches and accept their public keys.
 When using a private cache, you will also need to install an appropriate netrc
 file in `/etc/nix/daemon-netrc`.
 
-5.
-Start the agent with the command `hercules-agent --config agent.toml`.
+6.
+Start the agent with the command `hercules-agent --config agent.toml`, preferably via some process supervision system.

--- a/index.adoc
+++ b/index.adoc
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: Hercules CI Manual
+title: Hercules CI Documentation
 ---
 
 include::docs/index.adoc[]


### PR DESCRIPTION
- [x] how to pass `binary-caches.json` to linux/macos agents