### PR TITLE
Add instructions how to avoid compiling the agent

### DIFF
--- a/docs/modules/ROOT/pages/getting-started/deploy/nixos.adoc
+++ b/docs/modules/ROOT/pages/getting-started/deploy/nixos.adoc
@@ -9,6 +9,8 @@ deployment, you will use some project directory in place of `/etc/nixos`.
 
 == 1. Bootstrap
 
+include::partial$snippets/CachixBinaries.adoc[]
+
 include::partial$snippets/NixOSBootstrap.adoc[]
 
 == 2. Get a cluster join token.

--- a/docs/modules/ROOT/partials/snippets/CachixBinaries.adoc
+++ b/docs/modules/ROOT/partials/snippets/CachixBinaries.adoc
@@ -1,0 +1,10 @@
+[NOTE]
+====
+To avoid compiling the agent you can use binary cache to speed it up:
+
+[source,bash]
+----
+$ nix-env -iA cachix -f https://cachix.org/api/v1/install
+$ cachix use hercules-ci
+----
+====

--- a/docs/modules/ROOT/partials/snippets/Darwin.adoc
+++ b/docs/modules/ROOT/partials/snippets/Darwin.adoc
@@ -1,6 +1,8 @@
 
 WARNING: Evaluation https://github.com/hercules-ci/support/issues/24[currently] requires an `x86_64-linux` machine to be in your build cluster!
 
+include::CachixBinaries.adoc[]
+
 On macOS run:
 
 [source,bash]

--- a/docs/modules/ROOT/partials/snippets/Deploy.adoc
+++ b/docs/modules/ROOT/partials/snippets/Deploy.adoc
@@ -1,3 +1,5 @@
+include::CachixBinaries.adoc[]
+
 Deploy using:
 
 [source,bash]


### PR DESCRIPTION
A companion to https://github.com/hercules-ci/hercules-ci-agent/pull/110

- [x] agent release
- [ ] bump docs internally
