### PR TITLE
move reasoning for binary caches to the begining

### DIFF
--- a/docs/modules/ROOT/partials/snippets/BinaryCachesJson.adoc
+++ b/docs/modules/ROOT/partials/snippets/BinaryCachesJson.adoc
@@ -1,3 +1,7 @@
+WARNING: Although a single agent works with empty `{}` binary cache configuration,
+we highly recommend setting up a cache from the start. 
+Running without a cache will break some features and will cause unexpectedly long build times
+due to eventual garbage collection.
 
 On https://cachix.org[Cachix] you can create a binary cache. After you complete the process, gather the keys into a `binary-caches.json` file, replacing all placeholders:
 
@@ -19,5 +23,3 @@ On https://cachix.org[Cachix] you can create a binary cache. After you complete 
 
 // TODO: xref:reference:binary-cache-json.adoc[The `binary-caches.json` format]
 NOTE: For more detail, see https://docs.hercules-ci.com/hercules-ci/reference/binary-caches-json/[The `binary-caches.json` format] in the Reference.
-
-NOTE: Although a single-agent "cluster" works with an empty `{}` cache configuration, we highly recommend setting up a cache from the start. Running without a cache will break some features and will cause unexpectedly long build times due to automatic garbage collection.


### PR DESCRIPTION
As users first need to know if/when they need a binary cache.