### PR TITLE
No select shell prompts

### DIFF
--- a/docs/modules/ROOT/pages/getting-started/repository.adoc
+++ b/docs/modules/ROOT/pages/getting-started/repository.adoc
@@ -29,9 +29,9 @@ You can use an impure evaluation-time fetcher such as `builtins.fetchUrl`, altho
 The behavior of `nix-instantiate` serves as a reference for evaluation in Hercules CI.
 You may use the following command to test locally:
 +
-[source,bash]
+[source,shell]
 ----
-NIX_PATH="" nix-instantiate nix/ci.nix
+$ NIX_PATH="" nix-instantiate nix/ci.nix
 ----
 +
 This may produce a lot of output if you are using import from derivation. You may run it twice for clarity.

--- a/docs/modules/ROOT/pages/troubleshooting.adoc
+++ b/docs/modules/ROOT/pages/troubleshooting.adoc
@@ -44,7 +44,7 @@ in {
 (import ./default.nix).shells.projectShell
 ----
 
-[source,bash]
+[source,shell]
 ----
 $ nix-build
 /nix/store/...-hello-2.10

--- a/docs/modules/ROOT/partials/snippets/CachixBinaries.adoc
+++ b/docs/modules/ROOT/partials/snippets/CachixBinaries.adoc
@@ -2,7 +2,7 @@
 ====
 To avoid compiling the agent for hours you can use our binary cache to speed it up:
 
-[source,bash]
+[source,shell]
 ----
 $ nix-env -iA cachix -f https://cachix.org/api/v1/install
 $ cachix use hercules-ci

--- a/docs/modules/ROOT/partials/snippets/CachixDarwin.adoc
+++ b/docs/modules/ROOT/partials/snippets/CachixDarwin.adoc
@@ -1,8 +1,8 @@
 Save `binary-caches.json` on the target machine and install it by running:
 
-[source,bash]
+[source,shell]
 ----
-sudo install \
+$ sudo install \
     -o hercules-ci-agent  \
     -m 0600 \
     binary-caches.json \
@@ -11,7 +11,7 @@ sudo install \
 
 And activate via:
 
-[source,bash]
+[source,shell]
 ----
-./result/bin/darwin-installer
+$ sudo ./result/bin/darwin-installer
 ----

--- a/docs/modules/ROOT/partials/snippets/Darwin.adoc
+++ b/docs/modules/ROOT/partials/snippets/Darwin.adoc
@@ -5,13 +5,13 @@ include::CachixBinaries.adoc[]
 
 On macOS run:
 
-[source,bash]
+[source,shell]
 ----
-sh <(curl https://nixos.org/nix/install) --daemon
-source /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+[root@mac]# sh <(curl https://nixos.org/nix/install) --daemon
+[root@mac]# source /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
 
-nix-build https://github.com/hercules-ci/nix-darwin/archive/hercules-ci-agent.tar.gz -A installer
-./result/bin/darwin-installer
+[root@mac]# nix-build https://github.com/hercules-ci/nix-darwin/archive/hercules-ci-agent.tar.gz -A installer
+[root@mac]# ./result/bin/darwin-installer
 ----
 
 When asked for editing the `darwin-configuration.nix` add:

--- a/docs/modules/ROOT/partials/snippets/DarwinPostToken.adoc
+++ b/docs/modules/ROOT/partials/snippets/DarwinPostToken.adoc
@@ -1,13 +1,13 @@
 Save the token to a new file `cluster-join-token.key` on the target machine and run:
 
-[source,bash]
+[source,shell]
 ----
-sudo install \
+$ sudo install \
     -o hercules-ci-agent  \
     -m 0600 \
     cluster-join-token.key \
     /var/lib/hercules-ci-agent/secrets/cluster-join-token.key
-rm cluster-join-token.key
+$ rm cluster-join-token.key
 ----
 
 `tail -f /var/log/hercules-ci-agent.log` to see what is going on with your agent.

--- a/docs/modules/ROOT/partials/snippets/Deploy.adoc
+++ b/docs/modules/ROOT/partials/snippets/Deploy.adoc
@@ -2,7 +2,7 @@ include::CachixBinaries.adoc[]
 
 Deploy using:
 
-[source,bash]
+[source,shell]
 ----
 $ nix-shell -p nixops -I nixpkgs=http://nixos.org/channels/nixos-19.03/nixexprs.tar.xz
 $ nixops create -d my-agent ./hercules-ci-agents.nix ./hercules-ci-agents-target.nix

--- a/ui/partials/head-meta.hbs
+++ b/ui/partials/head-meta.hbs
@@ -11,6 +11,9 @@
   .nav-panel-menu {
     overflow: visible;
   }
+  code.language-shell .hljs-meta {
+    user-select: none;
+  }
 </style>
 <link
   rel="stylesheet"


### PR DESCRIPTION
 - unselectable prompts
 - better prompts

We need the `shell` language rather than `bash` to use this feature.